### PR TITLE
Possible hook for loading custom fonts.

### DIFF
--- a/QuestPDF/Drawing/CanvasCache.cs
+++ b/QuestPDF/Drawing/CanvasCache.cs
@@ -22,22 +22,24 @@ namespace QuestPDF.Drawing
                 };
             }
         }
-        
+
         internal static SKPaint ToPaint(this TextStyle style)
         {
             return Paints.GetOrAdd(style.ToString(), key => Convert(style));
-            
+
             static SKPaint Convert(TextStyle style)
             {
                 var slant = style.IsItalic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
-                
+
                 return new SKPaint
                 {
                     Color = SKColor.Parse(style.Color),
-                    Typeface = SKTypeface.FromFamilyName(style.FontType, (int)style.FontWeight, (int)SKFontStyleWidth.Normal, slant),
+                    Typeface = TextStyle.ConfiguredTypefaces.TryGetValue(style.FontType, out SKTypeface typeFace) ?
+                        typeFace :
+                        SKTypeface.FromFamilyName(style.FontType, (int)style.FontWeight, (int)SKFontStyleWidth.Normal, slant),
                     TextSize = style.Size,
                     TextEncoding = SKTextEncoding.Utf32,
-                    
+
                     TextAlign = style.Alignment switch
                     {
                         HorizontalAlignment.Left => SKTextAlign.Left,
@@ -52,7 +54,7 @@ namespace QuestPDF.Drawing
         internal static TextMeasurement BreakText(this TextStyle style, string text, float availableWidth)
         {
             var index = (int)style.ToPaint().BreakText(text, availableWidth, out var width);
-            
+
             return new TextMeasurement()
             {
                 LineIndex = index,

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -1,5 +1,5 @@
 ﻿using QuestPDF.Helpers;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace QuestPDF.Infrastructure
 {
@@ -15,7 +15,8 @@ namespace QuestPDF.Infrastructure
 
         public static TextStyle Default => new TextStyle();
 
-        internal static Dictionary<string, SkiaSharp.SKTypeface> ConfiguredTypefaces = new Dictionary<string, SkiaSharp.SKTypeface>();
+        internal static ConcurrentDictionary<string, SkiaSharp.SKTypeface> ConfiguredTypefaces = new ConcurrentDictionary<string, SkiaSharp.SKTypeface>();
+
         public static void ConfigureFontType(string fontType, SkiaSharp.SKTypeface typeFace)
         {
             ConfiguredTypefaces[fontType] = typeFace;

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -1,4 +1,5 @@
 ﻿using QuestPDF.Helpers;
+using System.Collections.Generic;
 
 namespace QuestPDF.Infrastructure
 {
@@ -13,6 +14,12 @@ namespace QuestPDF.Infrastructure
         internal bool IsItalic { get; set; } = false;
 
         public static TextStyle Default => new TextStyle();
+
+        internal static Dictionary<string, SkiaSharp.SKTypeface> ConfiguredTypefaces = new Dictionary<string, SkiaSharp.SKTypeface>();
+        public static void ConfigureFontType(string fontType, SkiaSharp.SKTypeface typeFace)
+        {
+            ConfiguredTypefaces[fontType] = typeFace;
+        }
         
         public override string ToString()
         {

--- a/QuestPDF/QuestPDF.csproj
+++ b/QuestPDF/QuestPDF.csproj
@@ -18,7 +18,7 @@
         <PackageTags>PDF file export generate create render portable document format quest free</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net462;netstandard2.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/QuestPDF/QuestPDF.csproj
+++ b/QuestPDF/QuestPDF.csproj
@@ -18,7 +18,7 @@
         <PackageTags>PDF file export generate create render portable document format quest free</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Potential solution for #19 

To use:
```
TextStyle.ConfigureFontType("fre3of9x", SkiaSharp.SKTypeface.FromFile("./Fonts/fre3of9x.ttf"))
```

Then elsewhere, can do:
```
TextStyle.Default.FontType("fre3of9x")
```

Similarly, could pre-load/configure other fonts (like Calibri) for environments that don't have them setup in the OS (such as AWS Lambdas).

I did test this approach on a lambda function, and it works.

Open to other ideas, this was just the immediate path that came to mind. Generally, I don't like config to be static like this, but QuestPDF is using a lot of statics already, so I think it'd fit.