### PR TITLE
SkipOnce element for different headers and footers

### DIFF
--- a/QuestPDF.ReportSample/Layouts/DifferentHeadersTemplate.cs
+++ b/QuestPDF.ReportSample/Layouts/DifferentHeadersTemplate.cs
@@ -1,0 +1,85 @@
+﻿using QuestPDF.Drawing;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.ReportSample.Layouts
+{
+    public class DifferentHeadersTemplate : IDocument
+    {
+        public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+
+        public void Compose(IDocumentContainer container)
+        {
+            container
+                .Page(page =>
+                {
+                    page.Margin(40);
+
+                    page.Size(PageSizes.A4);
+
+                    page.Header().Element(ComposeHeader);
+                    page.Content().Element(ComposeContent);
+                    page.Footer().Element(ComposeFooter);
+                });
+        }
+
+        private void ComposeHeader(IContainer container)
+        {
+            container.Background(Colors.Grey.Lighten3).Border(1).Stack(stack =>
+            {
+                stack.Item().ShowOnce().Padding(5).AlignMiddle().Row(row =>
+                {
+                    row.RelativeColumn(2).AlignMiddle().Text("PRIMARY HEADER", TextStyle.Default.Color(Colors.Grey.Darken3).Size(30).Bold());
+                    row.RelativeColumn(1).AlignRight().Box().AlignMiddle().Background(Colors.Blue.Darken2).Padding(30);
+                });
+                stack.Item().SkipOnce().Padding(5).Row(row =>
+                {
+                    row.RelativeColumn(2).Text("SECONDARY HEADER", TextStyle.Default.Color(Colors.Grey.Darken3).Size(30).Bold());
+                    row.RelativeColumn(1).AlignRight().Box().Background(Colors.Blue.Lighten4).Padding(15);
+                });
+            });
+        }
+
+        private void ComposeContent(IContainer container)
+        {
+            container.Stack(stack =>
+            {
+                stack.Item().PaddingVertical(80).Text("First");
+                stack.Item().PageBreak();
+                stack.Item().PaddingVertical(80).Text("Second");
+                stack.Item().PageBreak();
+                stack.Item().PaddingVertical(80).Text("Third");
+                stack.Item().PageBreak();
+            });
+        }
+
+        private void ComposeFooter(IContainer container)
+        {
+            container.Background(Colors.Grey.Lighten3).Stack(stack =>
+            {
+                stack.Item().ShowOnce().Background(Colors.Grey.Lighten3).Row(row =>
+                {
+                    row.RelativeColumn().Text(x =>
+                    {
+                        x.CurrentPageNumber();
+                        x.Span(" / ");
+                        x.TotalPages();
+                    });
+                    row.RelativeColumn().AlignRight().Text("Footer for header");
+                });
+
+                stack.Item().SkipOnce().Background(Colors.Grey.Lighten3).Row(row =>
+                {
+                    row.RelativeColumn().Text(x =>
+                    {
+                        x.CurrentPageNumber();
+                        x.Span(" / ");
+                        x.TotalPages();
+                    });
+                    row.RelativeColumn().AlignRight().Text("Footer for every page except header");
+                });
+            });
+        }
+    }
+}

--- a/QuestPDF/Elements/SkipOnce.cs
+++ b/QuestPDF/Elements/SkipOnce.cs
@@ -1,0 +1,34 @@
+﻿using QuestPDF.Drawing.SpacePlan;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Elements
+{
+    internal class SkipOnce : ContainerElement, IStateResettable
+    {
+        private bool firstPageWasSkiped;
+
+        public void ResetState()
+        {
+            firstPageWasSkiped = false;
+        }
+
+        internal override ISpacePlan Measure(Size availableSpace)
+        {
+            if (Child == null || !firstPageWasSkiped)
+                return new FullRender(Size.Zero);
+
+            return Child.Measure(availableSpace);
+        }
+
+        internal override void Draw(Size availableSpace)
+        {
+            if (Child == null)
+                return;
+
+            if (firstPageWasSkiped)
+                Child.Draw(availableSpace);
+
+            firstPageWasSkiped = true;
+        }
+    }
+}

--- a/QuestPDF/Fluent/ElementExtensions.cs
+++ b/QuestPDF/Fluent/ElementExtensions.cs
@@ -70,7 +70,12 @@ namespace QuestPDF.Fluent
         {
             return element.Element(new ShowOnce());
         }
-        
+
+        public static IContainer SkipOnce(this IContainer element)
+        {
+            return element.Element(new SkipOnce());
+        }
+
         public static IContainer ShowEntire(this IContainer element)
         {
             return element.Element(new ShowEntire());


### PR DESCRIPTION
Hi,

I have started migrating some reports in my company using QuestPdf library, and the results are very promising. However, some of our reports must have one header for the first page, and a different header for the rest of the pages. This pull request allows to achieve this feature.

I have created a new element named *SkipOnce* , that works in a similar way the element *ShowOnce* does. Combining those 2 elements, we could create the desired effect, writing a code like this:
```` csharp
page.Header().Stack(stack =>
{
    stack.Item().ShowOnce().Text("Primary header");
    stack.Item().SkipOnce().Text("Secondary header");
});
````

I have not implemented any unit tests for this, because I still do not understand how the unit tests for these elements exactly work, but I have implemented a template that prints 2 different headers called **DifferentHeadersTemplate**